### PR TITLE
chore: inject api endpoint

### DIFF
--- a/src/templates/plugins/prismic.js
+++ b/src/templates/plugins/prismic.js
@@ -21,6 +21,9 @@ export default async (context, inject) => {
       api() {
         return api
       },
+      apiEndpoint() {
+        return '<%= options.endpoint %>'
+      },
       predicates() {
         return Prismic.Predicates
       },


### PR DESCRIPTION
This PR adds an `apiEndpoint` computed prop to `$prismic`.

**why?**
I found more and more cases where we needed to display the `apiEndpoint` of a user inside components. This PR makes it accessible from anywhere, without the need to import the Nuxt config file

