### PR TITLE
chore: update homepage link

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "bugs": {
     "url": "https://github.com/nuxt-community/prismic-module/issues"
   },
-  "homepage": "https://prismic-nuxt.js.org",
+  "homepage": "https://prismic.nuxtjs.org",
   "dependencies": {
     "@prismicio/vue": "^2.0.7",
     "consola": "^2.15.0",


### PR DESCRIPTION
`package.json` was still referencing the old documentation website, updated it to the new one 🙂 