### PR TITLE
chore(release): 1.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.2.4](https://github.com/nuxt-community/prismic-module/compare/v1.2.3...v1.2.4) (2020-09-10)
+
+
+### Bug Fixes
+
+* use custom preview page if exists ([#101](https://github.com/nuxt-community/prismic-module/issues/101)) ([39d9dd5](https://github.com/nuxt-community/prismic-module/commit/39d9dd55a9e9c3540c6a377cb3e484121466265d))
+
 ### [1.2.3](https://github.com/nuxt-community/prismic-module/compare/v1.2.1...v1.2.3) (2020-07-17)
 
 

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "@nuxtjs/prismic",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Add Prismic to your NuxtJS project",
   "main": "src/index.js",
   "scripts": {
     "test": "npm run lint && npm run unit",
     "release": "yarn test && standard-version && git push --follow-tags && npm publish",
+    "standard-version": "standard-version",
     "unit": "jest",
     "lint": "eslint src"
   },


### PR DESCRIPTION
Release 1.2.4 (don't mind the branch name, typo)

https://github.com/nuxt-community/prismic-module/blob/2.1.4/CHANGELOG.md#124-2020-09-10

Will publish once merged~