### PR TITLE
Do not initialize the prismic API in static mode.

### DIFF
--- a/src/templates/plugins/prismic.js
+++ b/src/templates/plugins/prismic.js
@@ -71,7 +71,7 @@ export default async (context, inject) => {
           return PrismicDOM.Date(date)
         }
       },
-      <% if (!(process.client && process.static) && options.preview) { %>
+      <% if (!isClientStatic && options.preview) { %>
       async preview() {
         let url = '/'
         const { token, documentId } = query


### PR DESCRIPTION
This avoid an useless call to the Prismic API.

Fix #111