### PR TITLE
docs: invalid key used in example

### DIFF
--- a/docs/content/en/configuration.md
+++ b/docs/content/en/configuration.md
@@ -64,7 +64,7 @@ prismic: {
   // example querying a private Prismic repository
   // please note that the token will bleed in the front-end
   apiOptions: {
-    access_token: 'yourAccessToken'
+    accessToken: 'yourAccessToken'
   }
 }
 ```


### PR DESCRIPTION
Fixes #120 