### PR TITLE
docs: update `nuxt3` to `nuxt`

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ npm install --save-dev @nuxtjs/prismic@alpha # or yarn add --dev @nuxtjs/prismic
 Then, add `@nuxtjs/prismic` to the `modules` section of your Nuxt config and configure your Prismic API endpoint:
 
 ```javascript
-import { defineNuxtConfig } from 'nuxt3'
+import { defineNuxtConfig } from 'nuxt'
 
 export default defineNuxtConfig({
 	modules: ['@nuxtjs/prismic'],

--- a/docs/content/en/index.md
+++ b/docs/content/en/index.md
@@ -67,7 +67,7 @@ npm install --save-dev @nuxtjs/prismic@alpha
 Then, add `@nuxtjs/prismic` to the `modules` section of your Nuxt config and configure your Prismic API endpoint:
 
 ```javascript[nuxt.config.[jt]s]
-import { defineNuxtConfig } from 'nuxt3'
+import { defineNuxtConfig } from 'nuxt'
 
 export default defineNuxtConfig({
 	modules: ['@nuxtjs/prismic'],


### PR DESCRIPTION
importing nuxt3 throws an error for me.

<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [ ] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [ ] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
